### PR TITLE
Duplicate service configuration

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,7 +32,6 @@ final class AppServiceProvider extends ServiceProvider
         $this->configureDates();
         $this->configureUrls();
         $this->configureVite();
-        $this->configureDates();
     }
 
     /**


### PR DESCRIPTION
The `boot()` method in `AppServiceProvider` calls `configureDates()` twice, leading to unnecessary code execution.